### PR TITLE
Fixed all broken reference urls

### DIFF
--- a/notes/stories/film/film-scifi-1950s.st.txt
+++ b/notes/stories/film/film-scifi-1950s.st.txt
@@ -2881,8 +2881,7 @@ American nuclear tests in the Pacific stirs up a dinosaur-like monster that
 makes a B-line for Tokyo.
 
 :: References
-https://en.wikipedia.org/wiki/Godzilla
-_King_of_the_Monsters!
+https://en.wikipedia.org/wiki/Godzilla_King_of_the_Monsters!
 
 :: Genre
 sci-fi, kaiju
@@ -5941,8 +5940,7 @@ sources: the novel The Purple Cloud by M. P. Shiel and the story "End of the
 World" by Ferdinand Reyher.
 
 :: References
-https://en.wikipedia.org/wiki/The_World
-_the_Flesh_and_the_Devil_(1959_film)
+https://en.wikipedia.org/wiki/The_World_the_Flesh_and_the_Devil_(1959_film)
 
 :: Genre
 sci-fi
@@ -6295,8 +6293,7 @@ The Three Stooges are janitors working at a space center who accidentally
 blast off to Venus.
 
 :: References
-https://en.wikipedia.org/wiki/Have_Rocket
-_Will_Travel
+https://en.wikipedia.org/wiki/Have_Rocket_Will_Travel
 
 :: Genre
 sci-fi, comedy,

--- a/notes/stories/film/film-scifi-1960s.st.txt
+++ b/notes/stories/film/film-scifi-1960s.st.txt
@@ -983,8 +983,7 @@ The film concerns the events leading up to the total destruction of the
 mythical continent of Atlantis during the time of Ancient Greece.
 
 :: References
-https://en.wikipedia.org/wiki/Atlantis
-_the_Lost_Continent
+https://en.wikipedia.org/wiki/Atlantis_the_Lost_Continent
 
 :: Genre
 sci-fi,
@@ -3116,8 +3115,7 @@ in September 1965 by Continental Distributing as Ghidrah, the Three-Headed
 Monster.
 
 :: References
-https://en.wikipedia.org/wiki/Ghidorah
-_the_Three-Headed_Monster
+https://en.wikipedia.org/wiki/Ghidorah_the_Three-Headed_Monster
 
 :: Genre
 sci-fi, kaiju,
@@ -3747,8 +3745,7 @@ Gamera, the Giant Monster
 A giant, flying, fire breathing turtle is poised to destroy Tokyo.
 
 :: References
-https://en.wikipedia.org/wiki/Gamera
-_the_Giant_Monster
+https://en.wikipedia.org/wiki/Gamera_the_Giant_Monster
 
 :: Genre
 sci-fi
@@ -3899,8 +3896,7 @@ Corman's It Conquered the World (1956), which also featured an alien invader
 from Venus.
 
 :: References
-https://en.wikipedia.org/wiki/Zontar
-_the_Thing_from_Venus
+https://en.wikipedia.org/wiki/Zontar_the_Thing_from_Venus
 
 :: Genre
 sci-fi
@@ -4639,8 +4635,7 @@ Mike Halstead, a rogue cop, goes to the rescue in outer space. This includes
 rescuing his girlfriend Connie, who is also a captive of the mad scientist.
 
 :: References
-https://en.wikipedia.org/wiki/Wild
-_Wild_Planet
+https://en.wikipedia.org/wiki/Wild_Wild_Planet
 
 :: Genre
 sci-fi
@@ -4713,8 +4708,7 @@ The seventh film in the Godzilla franchise. This time Godzilla it faces the
 Sea Monster.
 
 :: References
-https://en.wikipedia.org/wiki/Ebirah
-_Horror_of_the_Deep
+https://en.wikipedia.org/wiki/Ebirah_Horror_of_the_Deep
 
 :: Genre
 sci-fi, kaiju,
@@ -5224,8 +5218,7 @@ Yongary, Monster from the Deep
 The giant monster Yongary attacks Seoul.
 
 :: References
-https://en.wikipedia.org/wiki/Yongary
-_Monster_from_the_Deep
+https://en.wikipedia.org/wiki/Yongary_Monster_from_the_Deep
 
 :: Genre
 sci-fi, kaiju
@@ -5629,8 +5622,7 @@ return him after one minute of observing the past, instead causes him to
 experience his past in a disjointed fashion. His fate is left ambiguous.
 
 :: References
-https://en.wikipedia.org/wiki/Je_t%27aime
-_je_t%27aime
+https://en.wikipedia.org/wiki/Je_t%27aime_je_t%27aime
 
 :: Genre
 sci-fi
@@ -5859,8 +5851,7 @@ A creature from outer space terrorizes the survivors of a plane crash at a
 remote and isolated location.
 
 :: References
-https://en.wikipedia.org/wiki/Goke
-_Body_Snatcher_from_Hell
+https://en.wikipedia.org/wiki/Goke_Body_Snatcher_from_Hell
 
 :: Genre
 sci-fi, horror

--- a/notes/stories/film/film-scifi-1970s.st.txt
+++ b/notes/stories/film/film-scifi-1970s.st.txt
@@ -1840,8 +1840,7 @@ sequel to the 1969 film The Computer Wore Tennis Shoes and was followed by
 1975's The Strongest Man in the World.
 
 :: References
-https://en.wikipedia.org/wiki/Now_You_See_Him
-_Now_You_Don%27t
+https://en.wikipedia.org/wiki/Now_You_See_Him_Now_You_Don%27t
 
 :: Genre
 sci-fi, comedy, family,
@@ -2762,8 +2761,7 @@ An Old English Sheepdog accidentally drinks a powder growth formula and
 expands to gigantic proportions.
 
 :: References
-https://en.wikipedia.org/wiki/Digby
-_the_Biggest_Dog_in_the_World
+https://en.wikipedia.org/wiki/Digby_the_Biggest_Dog_in_the_World
 
 :: Genre
 sci-fi, family,

--- a/notes/stories/film/film-scifi-1980s.st.txt
+++ b/notes/stories/film/film-scifi-1980s.st.txt
@@ -586,8 +586,7 @@ An easy-going man meets a free-spirited brunette and inherits from his
 millionaire uncle a gold watch that has the power to stop time.
 
 :: References
-https://en.wikipedia.org/wiki/The_Girl
-_the_Gold_Watch_%26_Everything_(film)
+https://en.wikipedia.org/wiki/The_Girl_the_Gold_Watch_%26_Everything_(film)
 
 :: Genre
 sci-fi
@@ -4002,8 +4001,7 @@ Set in 2019, after a nuclear apocalypse, a mercenary sets out to rescue the
 last fertile woman on Earth.
 
 :: References
-https://en.wikipedia.org/wiki/2019
-_After_the_Fall_of_New_York
+https://en.wikipedia.org/wiki/2019_After_the_Fall_of_New_York
 
 :: Genre
 sci-fi
@@ -6047,8 +6045,7 @@ the existence of The Ark is a myth planted by the main character, whose
 profession is to ensure that the morale is maintained.
 
 :: References
-https://en.wikipedia.org/wiki/O-Bi
-_O-Ba:_The_End_of_Civilization
+https://en.wikipedia.org/wiki/O-Bi_O-Ba:_The_End_of_Civilization
 
 :: Genre
 sci-fi
@@ -11697,8 +11694,7 @@ their backyard to return home while fending off insects and negotiating
 hazards. It is the first installment of the titular film series.
 
 :: References
-https://en.wikipedia.org/wiki/Honey
-_I_Shrunk_the_Kids
+https://en.wikipedia.org/wiki/Honey_I_Shrunk_the_Kids
 
 :: Genre
 sci-fi, comedy,

--- a/notes/stories/film/film-scifi-1990s.st.txt
+++ b/notes/stories/film/film-scifi-1990s.st.txt
@@ -3243,8 +3243,7 @@ growth machine, causing the toddler to gradually grow to enormous size. It is
 the second installment of the Honey, I Shrunk the Kids film series.
 
 :: References
-https://en.wikipedia.org/wiki/Honey
-_I_Blew_Up_the_Kid
+https://en.wikipedia.org/wiki/Honey_I_Blew_Up_the_Kid
 
 :: Genre
 sci-fi, comedy

--- a/notes/stories/film/film-scifi-before-1920.st.txt
+++ b/notes/stories/film/film-scifi-before-1920.st.txt
@@ -195,8 +195,7 @@ A professor and his students behold a mildly flirtatious eclipse between an
 anthropomorphic sun and moon.
 
 :: References
-https://en.wikipedia.org/wiki/The_Eclipse
-_or_the_Courtship_of_the_Sun_and_Moon
+https://en.wikipedia.org/wiki/The_Eclipse_or_the_Courtship_of_the_Sun_and_Moon
 
 :: Genre
 sci-fi

--- a/notes/stories/film/film-timeout-top100.st.txt
+++ b/notes/stories/film/film-timeout-top100.st.txt
@@ -724,8 +724,7 @@ festivals, including the most prestigious Cannes Grand Prix and was nominated
 for the Best Adapted Screenplay Oscar at the 19th Academy Awards.
 
 :: References
-https://en.wikipedia.org/wiki/Rome
-_Open_City
+https://en.wikipedia.org/wiki/Rome_Open_City
 
 :: Ratings
 5 <mikael>
@@ -2143,8 +2142,7 @@ group of conquistadores down the Amazon River in South America in search of
 the legendary city of gold, El Dorado.
 
 :: References
-https://en.wikipedia.org/wiki/Aguirre
-_the_Wrath_of_God
+https://en.wikipedia.org/wiki/Aguirre_the_Wrath_of_God
 
 :: Ratings
 5 <mikael>
@@ -2362,9 +2360,7 @@ to Jeanne's existence prepare for the climax on the third day, during which
 she murders a client.
 
 :: References
-https://en.wikipedia.org/wiki/Jeanne_Dielman
-_23_quai_du_Commerce
-_1080_Bruxelles
+https://en.wikipedia.org/wiki/Jeanne_Dielman_23_quai_du_Commerce_1080_Bruxelles
 
 :: Ratings
 

--- a/notes/stories/literature/play-shakespeare.st.txt
+++ b/notes/stories/literature/play-shakespeare.st.txt
@@ -98,8 +98,7 @@ apart by personal squabbles and petty jealousy.
 William Shakespeare
 
 :: References
-https://en.wikipedia.org/wiki/Henry_VI
-_Part_1
+https://en.wikipedia.org/wiki/Henry_VI_Part_1
 
 :: Ratings
 3 <mikael>
@@ -404,8 +403,7 @@ subverted in the pursuit of revenge and power.
 William Shakespeare
 
 :: References
-https://en.wikipedia.org/wiki/Henry_VI
-_Part_3
+https://en.wikipedia.org/wiki/Henry_VI_Part_3
 
 :: Ratings
 5 <mikael>
@@ -455,8 +453,7 @@ extremely popular play both with the public and critics.
 William Shakespeare
 
 :: References
-https://en.wikipedia.org/wiki/Henry_IV
-_Part_1
+https://en.wikipedia.org/wiki/Henry_IV_Part_1
 
 :: Ratings
 4 <mikael>
@@ -754,8 +751,7 @@ episodes in Part 1.
 William Shakespeare
 
 :: References
-https://en.wikipedia.org/wiki/Henry_IV
-_Part_2
+https://en.wikipedia.org/wiki/Henry_IV_Part_2
 
 :: Ratings
 4 <mikael>
@@ -1547,8 +1543,7 @@ victualler, panderer, dramatist and pamphleteer George Wilkins.
 William Shakespeare, George Wilkins
 
 :: References
-https://en.wikipedia.org/wiki/Pericles
-_Prince_of_Tyre
+https://en.wikipedia.org/wiki/Pericles_Prince_of_Tyre
 
 :: Ratings
 4 <mikael>
@@ -1853,8 +1848,7 @@ William Shakespeare
 
 :: References
 https://en.wikipedia.org/wiki/All%27s_Well_That_Ends_Well
-https://en.wikipedia.org/wiki/Summary_of_Decameron_tales#Ninth_tale_(III
-_9)
+https://en.wikipedia.org/wiki/Summary_of_Decameron_tales#Ninth_tale_(III_9)
 
 :: Ratings
 5 <mikael>

--- a/notes/stories/television/tv-iclaudius.st.txt
+++ b/notes/stories/television/tv-iclaudius.st.txt
@@ -20,8 +20,7 @@ Among many other productions and adaptations, Graves's Claudius novels have
 also been adapted for BBC Radio 4 broadcast (2010) and for the theatre (1972).
 
 :: References
-https://en.wikipedia.org/wiki/I
-_Claudius_(TV_series)
+https://en.wikipedia.org/wiki/I_Claudius_(TV_series)
 
 :: Collections
 Collection: I Claudius

--- a/notes/themes/primary.th.txt
+++ b/notes/themes/primary.th.txt
@@ -19916,8 +19916,7 @@ is risky and might backfire).
 human idea about life
 
 :: References
-https://en.wiktionary.org/wiki/if_it_ain%27t_broke
-_don%27t_fix_it
+https://en.wiktionary.org/wiki/if_it_ain%27t_broke_don%27t_fix_it
 
 
 if it sounds too good to be true it probably isn't true
@@ -20212,8 +20211,7 @@ short.
 human idea about life
 
 :: References
-https://en.wiktionary.org/wiki/in_for_a_penny
-_in_for_a_pound
+https://en.wiktionary.org/wiki/in_for_a_penny_in_for_a_pound
 
 
 in-law relationship
@@ -22330,8 +22328,7 @@ likely to die violent deaths.
 human idea about life
 
 :: References
-https://en.wikipedia.org/wiki/Live_by_the_sword
-_die_by_the_sword
+https://en.wikipedia.org/wiki/Live_by_the_sword_die_by_the_sword
 
 
 living corpse


### PR DESCRIPTION
Fixed reference urls that'd gotten split up into multiple lines on the "_" character so that they now are on a single line.

Example:

Reference urls like this

```:: References
https://en.wikipedia.org/wiki/Have_Rocket
_Will_Travel
```

are changed to this

```
:: References
https://en.wikipedia.org/wiki/Have_Rocket_Will_Travel
```