### PR TITLE
Add Story Format to every collection

### DIFF
--- a/notes/collections/scifi-collections.st.txt
+++ b/notes/collections/scifi-collections.st.txt
@@ -7,6 +7,9 @@ Alien
 :: Date
 1979-2017
 
+:: Story Format
+film
+
 :: Description
 The six feature films to date in the Alien franchise.
 
@@ -31,6 +34,9 @@ Alien Nation Films
 :: Date
 1988-1997
 
+:: Story Format
+film
+
 :: Description
 The six television films in the Alien Nation media franchise.
 
@@ -54,6 +60,9 @@ Appleseed Film Series
 
 :: Date
 2004-2014
+
+:: Story Format
+film
 
 :: Description
 Appleseed (Japanese: アップルシード, Hepburn: Appurushīdo) is a Japanese animated
@@ -80,6 +89,9 @@ Babylon 5 Films
 :: Date
 1993-2002
 
+:: Story Format
+film
+
 :: Description
 The six television films in the Babylon 5 media franchise.
 
@@ -104,6 +116,9 @@ Back to the Future
 :: Date
 1985-1990
 
+:: Story Format
+film
+
 :: Description
 The three feature films in the Back to the Future series
 
@@ -124,6 +139,9 @@ Bill and Ted Films
 
 :: Date
 1989-2020
+
+:: Story Format
+film
 
 :: Description
 The three films in the Bill & Ted film series.
@@ -146,6 +164,9 @@ Carnosaur
 :: Date
 1993-1996
 
+:: Story Format
+film
+
 :: Description
 The Carnosaur film series consists of B-movies produced by Roger Corman that
 feature genetically engineered dinosaurs running amok in various scenarios.
@@ -167,6 +188,9 @@ Critters
 
 :: Date
 1986-2019
+
+:: Story Format
+film
 
 :: Description
 The five films to date in Critters series which is about a group of malevolent
@@ -193,6 +217,9 @@ Cube Film Series
 
 :: Date
 1997-2004
+
+:: Story Format
+film
 
 :: Description
 Cube is a Canadian science fiction horror film series.
@@ -233,6 +260,9 @@ Cyborg
 :: Date
 1989-1995
 
+:: Story Format
+film
+
 :: Description
 Albert Pyun's Cyborg Trilogy.
 
@@ -254,6 +284,9 @@ Deep Blue Sea
 :: Date
 1999-2020
 
+:: Story Format
+film
+
 :: Description
 The three films in the Deep Blue Sea film series.
 
@@ -274,6 +307,9 @@ Frankenstein Films
 
 :: Date
 1910-2025
+
+:: Story Format
+film
 
 :: Description
 Cinematic adaptations of Mary Shelley's 1818 Gothic novel "Frankenstein; or,
@@ -306,6 +342,9 @@ Gamera
 :: Date
 1965-2006
 
+:: Story Format
+film
+
 :: Description
 Films featuring the giant turtle-like monster Gamera.
 
@@ -336,6 +375,9 @@ Ghostbusters
 :: Date
 1984-2016
 
+:: Story Format
+film
+
 :: Description
 The three feature films to date in the Ghostbusters franchise.
 
@@ -356,6 +398,9 @@ Giant monster films
 
 :: Date
 1933-2019
+
+:: Story Format
+film
 
 :: Description
 Films featuring giant monsters.
@@ -449,6 +494,9 @@ Godzilla
 :: Date
 1954-2021
 
+:: Story Format
+film
+
 :: Description
 Films featuring the giant monster Godzilla.
 
@@ -501,6 +549,9 @@ Honey I Shrunk the Kids
 :: Date
 1989-1997
 
+:: Story Format
+film
+
 :: Description
 The Honey, I Shrunk the Kids film franchise consists of a series of American
 family-science fiction-comedy films, based on a concept created by Stuart
@@ -525,6 +576,9 @@ Jurassic Park
 :: Date
 1993-2018
 
+:: Story Format
+film
+
 :: Description
 The five feature films to date in the Jurassic Park franchise.
 
@@ -547,6 +601,9 @@ Max Max
 
 :: Date
 1979-2015
+
+:: Story Format
+film
 
 :: Description
 The four films in the Australian dystopian action film series Mad Max, created
@@ -571,6 +628,9 @@ Man from Atlantis
 :: Date
 1977
 
+:: Story Format
+film
+
 :: Description
 The four television films that preceded the Man from Atlantis American science
 fiction television series that ran for 13 episodes on the NBC network during
@@ -594,6 +654,9 @@ Marvel Cinematic Universe
 
 :: Date
 2008-2019
+
+:: Story Format
+film
 
 :: Description
 Films from the Marvel Cinematic Universe which is an American media franchise
@@ -639,6 +702,9 @@ Men in Black
 :: Date
 1997-2019
 
+:: Story Format
+film
+
 :: Description
 The four films in the American science fiction action comedy film series based
 the on Malibu / Marvel comic book series The Men in Black by Lowell
@@ -663,6 +729,9 @@ Mimic Film Series
 :: Date
 1997-2003
 
+:: Story Format
+film
+
 :: Description
 Mimic is a science fiction action horror film series created in 1997.
 
@@ -685,6 +754,9 @@ Nemesis
 
 :: Date
 1992-2017
+
+:: Story Format
+film
 
 :: Description
 The five low-budget films in the Nemesis film series.
@@ -709,6 +781,9 @@ Not Quite Human
 :: Date
 1987-1992
 
+:: Story Format
+film
+
 :: Description
 The three made for television films based on the eponymous series of young
 adult novels by Seth McEvoy about a scientist and his android creation which
@@ -731,6 +806,9 @@ Planet of the Apes
 
 :: Date
 1968-2017
+
+:: Story Format
+film
 
 :: Description
 The nine films in the Planet of the Apes series.
@@ -760,6 +838,9 @@ Predator
 :: Date
 1987-2018
 
+:: Story Format
+film
+
 :: Description
 The four feature films to date in the original Predator franchise.
 
@@ -782,6 +863,9 @@ Quatermass
 :: Date
 1955-1967
 
+:: Story Format
+film
+
 :: Description
 Three adventures of Professor Bernard Quatermass in film.
 
@@ -803,6 +887,9 @@ Re-Animator Films
 :: Date
 1985-2003
 
+:: Story Format
+film
+
 :: Description
 The three films in the Re-Animator film series.
 
@@ -823,6 +910,9 @@ Resident Evil Film Series
 
 :: Date
 2002-2016
+
+:: Story Format
+film
 
 :: Description
 Resident Evil is a science fiction action-horror film series based on the
@@ -849,6 +939,9 @@ Robocop
 :: Date
 1987-2014
 
+:: Story Format
+film
+
 :: Description
 The four feature films to date in the Robocop franchise.
 
@@ -870,6 +963,9 @@ Skyline Films
 
 :: Date
 2010-2020
+
+:: Story Format
+film
 
 :: Description
 The films in the Skyline film franchise.
@@ -894,6 +990,9 @@ Species
 :: Date
 1995-2007
 
+:: Story Format
+film
+
 :: Description
 The four films in the Species film series.
 
@@ -915,6 +1014,9 @@ Spider-Man
 
 :: Date
 1977-2019
+
+:: Story Format
+film
 
 :: Description
 Films centered on the Marvel Comics character Spider-Man.
@@ -946,6 +1048,9 @@ Star Trek Films
 :: Date
 1979-2016
 
+:: Story Format
+film
+
 :: Description
 Star Trek feature films.
 
@@ -976,6 +1081,9 @@ Star Wars
 
 :: Date
 1977-2019
+
+:: Story Format
+film
 
 :: Description
 A collection of any and all films set in George Lucas' Star Wars universe.
@@ -1010,6 +1118,9 @@ Starship Troopers
 :: Date
 1997-2017
 
+:: Story Format
+film
+
 :: Description
 The five films in the Starship Troopers film series.
 
@@ -1033,6 +1144,9 @@ Super Giant
 :: Date
 1964
 
+:: Story Format
+film
+
 :: Description
 The four films in American adaptation of the Japanese Super Giant serial film
 series.
@@ -1055,6 +1169,9 @@ Superman
 
 :: Date
 1951-2017
+
+:: Story Format
+film
 
 :: Description
 The nine feature films in the Superman series.
@@ -1084,6 +1201,9 @@ TekWar Films
 :: Date
 1994
 
+:: Story Format
+film
+
 :: Description
 The four television films in the TekWar media franchise.
 
@@ -1106,6 +1226,9 @@ The Blob
 :: Date
 1958-1988
 
+:: Story Format
+film
+
 :: Description
 The three films in The Blob film series.
 
@@ -1126,6 +1249,9 @@ The Chronicles of Riddick Film Series
 
 :: Date
 2010-2020
+
+:: Story Format
+film
 
 :: Description
 The Chronicles of Riddick, is a science fiction action space Western film
@@ -1150,6 +1276,9 @@ The Fly
 :: Date
 1958-1989
 
+:: Story Format
+film
+
 :: Description
 The five films in the The Fly series.
 
@@ -1172,6 +1301,9 @@ The Incredible Hulk
 
 :: Date
 1977-2008
+
+:: Story Format
+film
 
 :: Description
 Films featuring the Marvel Comics character The Hulk as the main character.
@@ -1199,6 +1331,9 @@ The Matrix
 :: Date
 1999-2003
 
+:: Story Format
+film
+
 :: Description
 The Matrix film trilogy.
 
@@ -1219,6 +1354,9 @@ The Nutty Professor
 
 :: Date
 1963-2008
+
+:: Story Format
+film
 
 :: Description
 The four films to date in the The Nutty Professor series.
@@ -1241,6 +1379,9 @@ The Six Million Dollar Man
 
 :: Date
 1973-1994
+
+:: Story Format
+film
 
 :: Description
 The six made for television films in the The Six Million Dollar Man series.
@@ -1267,6 +1408,9 @@ The Stepford Wives
 :: Date
 1975-2004
 
+:: Story Format
+film
+
 :: Description
 The Stepford Wives original film, its television film sequels, and feature
 film remake.
@@ -1291,6 +1435,9 @@ The Terminator
 :: Date
 1984-2019
 
+:: Story Format
+film
+
 :: Description
 The six feature films to date in The Terminator franchise.
 
@@ -1314,6 +1461,9 @@ The Twilight Zone Films
 
 :: Date
 1983-1994
+
+:: Story Format
+film
 
 :: Description
 Stories from the two Twilight Zone films: Twilight Zone: The Movie (1984) and
@@ -1341,6 +1491,9 @@ Trancers
 :: Date
 1984-2002
 
+:: Story Format
+film
+
 :: Description
 The six feature films and one short film in the Trancers film series.
 
@@ -1365,6 +1518,9 @@ Transformers
 
 :: Date
 1986-2018
+
+:: Story Format
+film
 
 :: Description
 Films based on the Transformers franchise which centers on extraterrestrial
@@ -1393,6 +1549,9 @@ Universal Soldier
 :: Date
 1992-2012
 
+:: Story Format
+film
+
 :: Description
 The six films in the Universal Soldier film series.
 
@@ -1417,6 +1576,9 @@ Watchers
 :: Date
 1988-1998
 
+:: Story Format
+film
+
 :: Description
 The four films in the Watchers film series.
 
@@ -1438,6 +1600,9 @@ X-men
 
 :: Date
 2000-2019
+
+:: Story Format
+film
 
 :: Description
 X-Men is an American superhero film series based on the fictional superhero
@@ -1470,6 +1635,9 @@ Xtro
 
 :: Date
 1982-1995
+
+:: Story Format
+film
 
 :: Description
 The three films in the low-budget British science fiction/horror Xtro series.

--- a/notes/collections/the-twilight-zone.st.txt
+++ b/notes/collections/the-twilight-zone.st.txt
@@ -7,6 +7,9 @@ The Twilight Zone Franchise
 :: Date
 1959-2020
 
+:: Story Format
+tv
+
 :: Description
 All Twilight Zone television and film stories.
 

--- a/notes/stories/film/film-academyaward-winners.st.txt
+++ b/notes/stories/film/film-academyaward-winners.st.txt
@@ -7,6 +7,9 @@ Academy Award Best Picture Winners
 :: Date
 1930-
 
+:: Story Format
+film
+
 :: Description
 Films that have won the Academy Award for Best Picture.
 

--- a/notes/stories/film/film-akira-kurosawa.st.txt
+++ b/notes/stories/film/film-akira-kurosawa.st.txt
@@ -7,6 +7,9 @@ Akira Kurosawa
 :: Date
 1949-1985
 
+:: Story Format
+film
+
 :: Description
 Films written or directed by Akira Kurosawa.
 

--- a/notes/stories/film/film-alfred-hitchcock.st.txt
+++ b/notes/stories/film/film-alfred-hitchcock.st.txt
@@ -7,6 +7,9 @@ Alfred Hitchcock
 :: Date
 1922-1993
 
+:: Story Format
+film
+
 :: Description
 Films written or directed by Alfred Hitchcock.
 

--- a/notes/stories/film/film-bfi-top100.st.txt
+++ b/notes/stories/film/film-bfi-top100.st.txt
@@ -7,6 +7,9 @@ BFI Top 100 films
 :: Date
 1920-2017
 
+:: Story Format
+film
+
 :: Description
 This is a collection of movies that appeared on the top 100 list of BFI, the
 British Film Institute.

--- a/notes/stories/film/film-federico-fellini.st.txt
+++ b/notes/stories/film/film-federico-fellini.st.txt
@@ -7,6 +7,9 @@ Federico Fellini
 :: Date
 1945–1992
 
+:: Story Format
+film
+
 :: Description
 Films written or directed by Federico Fellini.
 

--- a/notes/stories/film/film-ingmar-bergman.st.txt
+++ b/notes/stories/film/film-ingmar-bergman.st.txt
@@ -7,6 +7,9 @@ Ingmar Bergman
 :: Date
 1944-2003
 
+:: Story Format
+film
+
 :: Description
 Films written or directed by Ingmar Bergman.
 

--- a/notes/stories/film/film-mvad.st.txt
+++ b/notes/stories/film/film-mvad.st.txt
@@ -7,6 +7,9 @@ M-VAD Names Dataset films
 :: Date
 2012-2022
 
+:: Story Format
+film
+
 :: Description
 This is a collection of movies that appear on the latest version of the M-VAD
 Names Dataset.

--- a/notes/stories/film/film-notable-1939.st.txt
+++ b/notes/stories/film/film-notable-1939.st.txt
@@ -7,6 +7,9 @@ Notable films of 1939
 :: Date
 1939
 
+:: Story Format
+film
+
 :: Description
 Films of note that were released in 1939.
 

--- a/notes/stories/film/film-rottentomatoes-top100.st.txt
+++ b/notes/stories/film/film-rottentomatoes-top100.st.txt
@@ -7,6 +7,9 @@ Rotten Tomatoes Top 100 films
 :: Date
 1920-2017
 
+:: Story Format
+film
+
 :: Description
 This is a collection of movies that (by one metric or another) can be
 considered as amongst the top rated on Rotten Tomatoes. By and large, recent

--- a/notes/stories/film/film-scifi-1920s.st.txt
+++ b/notes/stories/film/film-scifi-1920s.st.txt
@@ -7,6 +7,9 @@ Science fiction films of the 1920s
 :: Date
 1920-1929
 
+:: Story Format
+film
+
 :: Description
 Science fiction films that premiered between 1 January 1920 and 31 December
 1929.

--- a/notes/stories/film/film-scifi-1930s.st.txt
+++ b/notes/stories/film/film-scifi-1930s.st.txt
@@ -7,6 +7,9 @@ Science fiction films of the 1930s
 :: Date
 1930-1939
 
+:: Story Format
+film
+
 :: Description
 Science fiction films that premiered between 1 January 1930 and 31 December
 1939.

--- a/notes/stories/film/film-scifi-1940s.st.txt
+++ b/notes/stories/film/film-scifi-1940s.st.txt
@@ -7,6 +7,9 @@ Science fiction films of the 1940s
 :: Date
 1940-1949
 
+:: Story Format
+film
+
 :: Description
 Science fiction films that premiered between 1 January 1940 and 31 December
 1949.

--- a/notes/stories/film/film-scifi-1950s.st.txt
+++ b/notes/stories/film/film-scifi-1950s.st.txt
@@ -7,6 +7,9 @@ Science fiction films of the 1950s
 :: Date
 1950-1959
 
+:: Story Format
+film
+
 :: Description
 Science fiction films that premiered between 1 January 1950 and 31 December
 1959.

--- a/notes/stories/film/film-scifi-1960s.st.txt
+++ b/notes/stories/film/film-scifi-1960s.st.txt
@@ -7,6 +7,9 @@ Science fiction films of the 1960s
 :: Date
 1960-1969
 
+:: Story Format
+film
+
 :: Description
 Science fiction films that premiered between 1 January 1960 and 31 December
 1969.

--- a/notes/stories/film/film-scifi-1970s.st.txt
+++ b/notes/stories/film/film-scifi-1970s.st.txt
@@ -7,6 +7,9 @@ Science fiction films of the 1970s
 :: Date
 1970-1979
 
+:: Story Format
+film
+
 :: Description
 Science fiction films that premiered between 1 January 1970 and 31 December
 1979.

--- a/notes/stories/film/film-scifi-1980s.st.txt
+++ b/notes/stories/film/film-scifi-1980s.st.txt
@@ -7,6 +7,9 @@ Science fiction films of the 1980s
 :: Date
 1980-1989
 
+:: Story Format
+film
+
 :: Description
 Science fiction films that premiered between 1 January 1980 and 31 December
 1989.
@@ -11203,6 +11206,9 @@ Time Out
 :: Date
 1983-06-24
 
+:: Story Format
+film
+
 :: Description
 A man is left bitter after being passed over for a promotion in favor of a
 Jewish co-worker.
@@ -11230,6 +11236,9 @@ Kick the Can
 :: Date
 1983-06-24
 
+:: Story Format
+film
+
 :: Description
 An old man with an optimistic outlook on life moves into a depressing senior's
 home.
@@ -11256,6 +11265,9 @@ It's a Good Life
 
 :: Date
 1983-06-24
+
+:: Story Format
+film
 
 :: Description
 A young woman is held captive by a spoiled little boy with magic powers.
@@ -11289,6 +11301,9 @@ Nightmare at 20,000 Feet
 
 :: Date
 1983-06-24
+
+:: Story Format
+film
 
 :: Description
 The story follows the only passenger on an airline flight to notice a hideous

--- a/notes/stories/film/film-scifi-1990s.st.txt
+++ b/notes/stories/film/film-scifi-1990s.st.txt
@@ -7,6 +7,9 @@ Science fiction films of the 1990s
 :: Date
 1990-1999
 
+:: Story Format
+film
+
 :: Description
 Science fiction films that premiered between 1 January 1990 and 31 December
 1999.
@@ -11548,6 +11551,9 @@ The Theatre
 :: Date
 1994-05-19
 
+:: Story Format
+film
+
 :: Description
 A young woman sees scenes from her past and future on the screen whenever she
 goes to the cinema.
@@ -11576,6 +11582,9 @@ Where the Dead Are
 
 :: Date
 1994-05-19
+
+:: Story Format
+film
 
 :: Description
 An American Civil War era physician searches for the secret to immortality.

--- a/notes/stories/film/film-scifi-2000s.st.txt
+++ b/notes/stories/film/film-scifi-2000s.st.txt
@@ -7,6 +7,9 @@ Science fiction films of the 2000s
 :: Date
 2000-2009
 
+:: Story Format
+film
+
 :: Description
 Science fiction films that premiered between 1 January 2000 and 31 December
 2009.

--- a/notes/stories/film/film-scifi-2010s.st.txt
+++ b/notes/stories/film/film-scifi-2010s.st.txt
@@ -7,6 +7,9 @@ Science fiction films of the 2010s
 :: Date
 2010-2019
 
+:: Story Format
+film
+
 :: Description
 Science fiction films that premiered between 1 January 2010 and 31 December
 2019.

--- a/notes/stories/film/film-scifi-2020s.st.txt
+++ b/notes/stories/film/film-scifi-2020s.st.txt
@@ -7,6 +7,9 @@ Science fiction films of the 2020s
 :: Date
 2020-2029
 
+:: Story Format
+film
+
 :: Description
 Science fiction films that premiered between 1 January 2020 and 31 December
 2029.

--- a/notes/stories/film/film-scifi-before-1920.st.txt
+++ b/notes/stories/film/film-scifi-before-1920.st.txt
@@ -7,6 +7,9 @@ Science fiction films before 1920
 :: Date
 1895-1919
 
+:: Story Format
+film
+
 :: Description
 Science fiction films that premiered prior to 1 January 1920.
 

--- a/notes/stories/film/film-timeout-top100.st.txt
+++ b/notes/stories/film/film-timeout-top100.st.txt
@@ -7,6 +7,9 @@ Time Out magazine's Top 100 films
 :: Date
 1920-2017
 
+:: Story Format
+film
+
 :: Description
 This is a collection of movies that the magazine Time Out has listed as being
 among the top 100 movies of all times.

--- a/notes/stories/film/film-tripod.st.txt
+++ b/notes/stories/film/film-tripod.st.txt
@@ -7,6 +7,9 @@ TRIPOD films
 :: Date
 1959-2020
 
+:: Story Format
+film
+
 :: Description
 The 99 films in the TuRnIng POint Dataset (TRIPOD).
 

--- a/notes/stories/literature/novel-apuleius.st.txt
+++ b/notes/stories/literature/novel-apuleius.st.txt
@@ -7,6 +7,9 @@ The Golden Ass
 :: Date
 180
 
+:: Story Format
+prose
+
 :: Description
 The Metamorphoses of Apuleius, which Augustine of Hippo referred to as The
 Golden Ass (Asinus aureus), is the only ancient Roman novel in Latin to

--- a/notes/stories/literature/play-georgebernardshaw.st.txt
+++ b/notes/stories/literature/play-georgebernardshaw.st.txt
@@ -7,6 +7,9 @@ George Bernard Shaw Plays
 :: Date
 1884-1913
 
+:: Story Format
+stage
+
 :: Description
 Plays written by the Irish playwright, critic, polemicist and political
 activist George Bernard Shaw.

--- a/notes/stories/literature/play-henrikibsen.st.txt
+++ b/notes/stories/literature/play-henrikibsen.st.txt
@@ -7,6 +7,9 @@ Henrik Ibsen Plays
 :: Date
 1882-1894
 
+:: Story Format
+stage
+
 :: Description
 Plays written by the Norwegian playwright and theater director Henrik Ibsen.
 

--- a/notes/stories/literature/play-shakespeare.st.txt
+++ b/notes/stories/literature/play-shakespeare.st.txt
@@ -7,6 +7,9 @@ William Shakespeare Plays
 :: Date
 1602-1606
 
+:: Story Format
+stage
+
 :: Description
 Plays written by the English playwright, poet, and actor William Shakespeare.
 

--- a/notes/stories/literature/play-terence.st.txt
+++ b/notes/stories/literature/play-terence.st.txt
@@ -7,6 +7,9 @@ Terence Plays
 :: Date
 166 BC-160 BC
 
+:: Story Format
+stage
+
 :: Description
 Plays authored by the Roman-African playwright Terence.
 

--- a/notes/stories/literature/shortstory-amazingstories.st.txt
+++ b/notes/stories/literature/shortstory-amazingstories.st.txt
@@ -7,6 +7,9 @@ Amazing Stories
 :: Date
 1926-1930
 
+:: Story Format
+prose
+
 :: Description
 Amazing Stories is an American science fiction magazine launched in April 1926
 by Hugo Gernsback's Experimenter Publishing. It was the first magazine devoted

--- a/notes/stories/literature/writing-aesop.st.txt
+++ b/notes/stories/literature/writing-aesop.st.txt
@@ -7,6 +7,9 @@ Aesop's Fables
 :: Date
 564 BC
 
+:: Story Format
+prose
+
 :: Description
 Aesop's Fables, or the Aesopica, is a collection of fables credited to Aesop,
 a slave and storyteller believed to have lived in ancient Greece between 620

--- a/notes/stories/literature/writing-boccaccio.st.txt
+++ b/notes/stories/literature/writing-boccaccio.st.txt
@@ -7,6 +7,9 @@ The Decameron
 :: Date
 1353
 
+:: Story Format
+prose
+
 :: Description
 The Decameron (/dɪˈkæmərən/; Italian: Decameron [deˈkaːmeron, dekameˈrɔn,
 -ˈron] or Decamerone [dekameˈroːne]), subtitled Prince Galehaut (Old Italian:

--- a/notes/stories/television/tv-alfredhitchcockpresents.st.txt
+++ b/notes/stories/television/tv-alfredhitchcockpresents.st.txt
@@ -7,6 +7,9 @@ Alfred Hitchcock Presents
 :: Date
 1955-1962
 
+:: Story Format
+tv
+
 :: Description
 Alfred Hitchcock Presents is an American television anthology series created,
 hosted, and produced by Alfred Hitchcock, and aired on CBS and NBC between

--- a/notes/stories/television/tv-amazingstories1985.st.txt
+++ b/notes/stories/television/tv-amazingstories1985.st.txt
@@ -7,6 +7,9 @@ Amazing Stories
 :: Date
 1985-1987
 
+:: Story Format
+tv
+
 :: Description
 Amazing Stories is an American anthology television series created by Steven
 Spielberg, that originally ran on NBC in the United States from September 29,

--- a/notes/stories/television/tv-amazingstories2020.st.txt
+++ b/notes/stories/television/tv-amazingstories2020.st.txt
@@ -7,6 +7,9 @@ Amazing Stories
 :: Date
 2020
 
+:: Story Format
+tv
+
 :: Description
 Amazing Stories is an American anthology television series based on the
 original television series of the same name created by Steven Spielberg. The

--- a/notes/stories/television/tv-babylon5.st.txt
+++ b/notes/stories/television/tv-babylon5.st.txt
@@ -7,6 +7,9 @@ Babylon 5
 :: Date
 1993-1998
 
+:: Story Format
+tv
+
 :: Description
 Babylon 5 is an American science fiction television series created by writer
 and producer J. Michael Straczynski, under the Babylonian Productions label,

--- a/notes/stories/television/tv-blackmirror.st.txt
+++ b/notes/stories/television/tv-blackmirror.st.txt
@@ -7,6 +7,9 @@ Black Mirror
 :: Date
 2011-2019
 
+:: Story Format
+tv
+
 :: Description
 Black Mirror is a British anthology science fiction television series created
 by Charlie Brooker, with Brooker and Annabel Jones serving as the programme

--- a/notes/stories/television/tv-bridesheadrevisited1981.st.txt
+++ b/notes/stories/television/tv-bridesheadrevisited1981.st.txt
@@ -7,6 +7,9 @@ Brideshead Revisited
 :: Date
 1981
 
+:: Story Format
+tv
+
 :: Description
 Brideshead Revisited is a 1981 British television serial starring Jeremy Irons
 and Anthony Andrews. It was produced by Granada Television for broadcast by

--- a/notes/stories/television/tv-columbo.st.txt
+++ b/notes/stories/television/tv-columbo.st.txt
@@ -7,6 +7,9 @@ Columbo
 :: Date
 1971-2003
 
+:: Story Format
+tv
+
 :: Description
 Columbo is an American crime drama television series starring Peter Falk as
 Lieutenant Columbo, a homicide detective with the Los Angeles Police

--- a/notes/stories/television/tv-electricdreams.st.txt
+++ b/notes/stories/television/tv-electricdreams.st.txt
@@ -7,6 +7,9 @@ Electric Dreams
 :: Date
 2017-2018
 
+:: Story Format
+tv
+
 :: Description
 Philip K. Dick's Electric Dreams, or simply Electric Dreams, is a science
 fiction television anthology series based on the works of Philip K. Dick. The

--- a/notes/stories/television/tv-faeritaletheatre1982.st.txt
+++ b/notes/stories/television/tv-faeritaletheatre1982.st.txt
@@ -7,6 +7,9 @@ Faerie Tale Theatre
 :: Date
 1982-1987
 
+:: Story Format
+tv
+
 :: Description
 Faerie Tale Theatre (also known as Shelley Duvall's Faerie Tale Theatre) is an
 American live-action fairytale fantasy anthology television series of 27

--- a/notes/stories/television/tv-futurama.st.txt
+++ b/notes/stories/television/tv-futurama.st.txt
@@ -7,6 +7,9 @@ Futurama
 :: Date
 1999-2013
 
+:: Story Format
+tv
+
 :: Description
 Futurama is an American animated sitcom created by Matt Groening for the Fox
 Broadcasting Company. The series follows the adventures of slacker Philip J.

--- a/notes/stories/television/tv-gameofthrones.st.txt
+++ b/notes/stories/television/tv-gameofthrones.st.txt
@@ -7,6 +7,9 @@ Game of Thrones
 :: Date
 2011-2019
 
+:: Story Format
+tv
+
 :: Description
 Game of Thrones is an American fantasy drama television series created by
 David Benioff and D. B. Weiss. It is an adaptation of A Song of Ice and Fire,

--- a/notes/stories/television/tv-guillermocacabinet.st.txt
+++ b/notes/stories/television/tv-guillermocacabinet.st.txt
@@ -7,6 +7,9 @@ Guillermo del Toro's Cabinet of Curiosities
 :: Date
 2022
 
+:: Story Format
+tv
+
 :: Description
 Guillermo del Toro's Cabinet of Curiosities is an American horror anthology
 streaming television series created by Guillermo del Toro for Netflix. It

--- a/notes/stories/television/tv-iclaudius.st.txt
+++ b/notes/stories/television/tv-iclaudius.st.txt
@@ -7,6 +7,9 @@ I, Claudius
 :: Date
 1976
 
+:: Story Format
+tv
+
 :: Description
 I, Claudius is a 1976 BBC Television adaptation of Robert Graves' I, Claudius
 and Claudius the God. Written by Jack Pulman, it starred Derek Jacobi as

--- a/notes/stories/television/tv-lovedeathrobots2019.st.txt
+++ b/notes/stories/television/tv-lovedeathrobots2019.st.txt
@@ -7,6 +7,9 @@ Love, Death & Robots
 :: Date
 2019-2021
 
+:: Story Format
+tv
+
 :: Description
 Love, Death & Robots (stylized as LOVE DEATH + ROBOTS; represented in emoji
 form as ❤️❌🤖) is an adult animated anthology television series created by Tim

--- a/notes/stories/television/tv-murderbot2025.st.txt
+++ b/notes/stories/television/tv-murderbot2025.st.txt
@@ -7,6 +7,9 @@ Murderbot
 :: Date
 2025
 
+:: Story Format
+tv
+
 :: Description
 Murderbot is an American science fiction action comedy television series
 created by Paul Weitz and Chris Weitz for Apple TV+. It is based on All

--- a/notes/stories/television/tv-night-gallery.st.txt
+++ b/notes/stories/television/tv-night-gallery.st.txt
@@ -7,6 +7,9 @@ Night Gallery
 :: Date
 1969-1973
 
+:: Story Format
+tv
+
 :: Description
 Night Gallery is an American anthology series that aired on NBC from 1969 to
 1973, featuring stories of horror and the macabre.

--- a/notes/stories/television/tv-pieceofcake1988.st.txt
+++ b/notes/stories/television/tv-pieceofcake1988.st.txt
@@ -7,6 +7,9 @@ Piece of Cake
 :: Date
 1988
 
+:: Story Format
+tv
+
 :: Description
 Piece of Cake is a 1988 British six-part television serial depicting the life
 of a Royal Air Force fighter squadron from the day of the British entry into

--- a/notes/stories/television/tv-raybradburytheater1985.st.txt
+++ b/notes/stories/television/tv-raybradburytheater1985.st.txt
@@ -7,6 +7,9 @@ The Ray Bradbury Theater
 :: Date
 1985-1992
 
+:: Story Format
+tv
+
 :: Description
 The Ray Bradbury Theatre is an anthology series that ran for three seasons on
 First Choice Superchannel in Canada and HBO in the United States from 1985 to

--- a/notes/stories/television/tv-realhumans2012.st.txt
+++ b/notes/stories/television/tv-realhumans2012.st.txt
@@ -7,6 +7,9 @@ Real Humans
 :: Date
 2012-2014
 
+:: Story Format
+tv
+
 :: Description
 Real Humans (Swedish: Äkta människor) is a 2012 Swedish science fiction/drama
 series set in an alternative near-future version of Sweden where consumer-

--- a/notes/stories/television/tv-reddwarf1988.st.txt
+++ b/notes/stories/television/tv-reddwarf1988.st.txt
@@ -7,6 +7,9 @@ Red Dwarf
 :: Date
 1988-2017
 
+:: Story Format
+tv
+
 :: Description
 Red Dwarf is a British science fiction comedy franchise created by Rob Grant
 and Doug Naylor which primarily consists of a television sitcom that aired on

--- a/notes/stories/television/tv-sherlock.st.txt
+++ b/notes/stories/television/tv-sherlock.st.txt
@@ -7,6 +7,9 @@ Sherlock
 :: Date
 2010-2017
 
+:: Story Format
+tv
+
 :: Description
 Sherlock is a British crime drama television series based on Sir Arthur Conan
 Doyle's Sherlock Holmes detective stories. Created by Steven Moffat and Mark

--- a/notes/stories/television/tv-startrek-discovery.st.txt
+++ b/notes/stories/television/tv-startrek-discovery.st.txt
@@ -7,6 +7,9 @@ Star Trek: Discovery
 :: Date
 2017-
 
+:: Story Format
+tv
+
 :: Description
 Star Trek: Discovery is an American television series created for CBS All
 Access by Bryan Fuller and Alex Kurtzman. It is the first series developed

--- a/notes/stories/television/tv-startrek-ds9.st.txt
+++ b/notes/stories/television/tv-startrek-ds9.st.txt
@@ -7,6 +7,9 @@ Star Trek: Deep Space Nine
 :: Date
 1993-1999
 
+:: Story Format
+tv
+
 :: Description
 Star Trek: Deep Space Nine (sometimes abbreviated to DS9) is a science fiction
 television series set in the Star Trek universe in the Milky Way galaxy, in

--- a/notes/stories/television/tv-startrek-enterprise.st.txt
+++ b/notes/stories/television/tv-startrek-enterprise.st.txt
@@ -7,6 +7,9 @@ Star Trek: Enterprise
 :: Date
 2001-2005
 
+:: Story Format
+tv
+
 :: Description
 Star Trek: Enterprise (ENT) (titled simply Enterprise until the third episode
 of season three) is an American science fiction television series created by

--- a/notes/stories/television/tv-startrek-tas.st.txt
+++ b/notes/stories/television/tv-startrek-tas.st.txt
@@ -7,6 +7,9 @@ Star Trek: The Animated Series
 :: Date
 1973-1974
 
+:: Story Format
+tv
+
 :: Description
 Star Trek: The Animated Series (originally known simply as Star Trek but also
 known as The Animated Adventures of Gene Roddenberry's Star Trek) is a 1973

--- a/notes/stories/television/tv-startrek-tng.st.txt
+++ b/notes/stories/television/tv-startrek-tng.st.txt
@@ -7,6 +7,9 @@ Star Trek: The Next Generation
 :: Date
 1987-1994
 
+:: Story Format
+tv
+
 :: Description
 Star Trek: The Next Generation (abbreviated as TNG and ST:TNG) is an American
 science-fiction television series in the Star Trek franchise created by Gene

--- a/notes/stories/television/tv-startrek-tos.st.txt
+++ b/notes/stories/television/tv-startrek-tos.st.txt
@@ -7,6 +7,9 @@ Star Trek: The Original Series
 :: Date
 1966-1969
 
+:: Story Format
+tv
+
 :: Description
 Star Trek is an American science fiction television series created by Gene
 Roddenberry that follows the adventures of the starship USS Enterprise

--- a/notes/stories/television/tv-startrek-voyager.st.txt
+++ b/notes/stories/television/tv-startrek-voyager.st.txt
@@ -7,6 +7,9 @@ Star Trek: Voyager
 :: Date
 1995-2001
 
+:: Story Format
+tv
+
 :: Description
 Star Trek: Voyager is a science fiction television series set in the Star Trek
 universe that debuted in 1995 and ended its original run in 2001, with a

--- a/notes/stories/television/tv-talesfromthecrypt1989.st.txt
+++ b/notes/stories/television/tv-talesfromthecrypt1989.st.txt
@@ -7,6 +7,9 @@ Tales from the Crypt
 :: Date
 1989-1996
 
+:: Story Format
+tv
+
 :: Description
 Tales from the Crypt, sometimes titled HBO's Tales from the Crypt, is an
 American horror anthology television series that ran from June 10, 1989, to

--- a/notes/stories/television/tv-talesfromtheloop.st.txt
+++ b/notes/stories/television/tv-talesfromtheloop.st.txt
@@ -7,6 +7,9 @@ Tales from the Loop
 :: Date
 2020
 
+:: Story Format
+tv
+
 :: Description
 Tales from the Loop is an American science fiction drama television series
 developed and written by Nathaniel Halpern based on the art book of the same

--- a/notes/stories/television/tv-talesoftheunexpected.st.txt
+++ b/notes/stories/television/tv-talesoftheunexpected.st.txt
@@ -7,6 +7,9 @@ Tales of the Unexpected
 :: Date
 1979-1988
 
+:: Story Format
+tv
+
 :: Description
 Tales of the Unexpected is a British television series which aired between
 1979 and 1988.Each episode tells a story, often with sinister and wryly

--- a/notes/stories/television/tv-thealfredhitchcockhour.st.txt
+++ b/notes/stories/television/tv-thealfredhitchcockhour.st.txt
@@ -7,6 +7,9 @@ The Alfred Hitchcock Hour
 :: Date
 1962-1965
 
+:: Story Format
+tv
+
 :: Description
 Alfred Hitchcock Presents is an American television anthology series created,
 hosted, and produced by Alfred Hitchcock, and aired on CBS and NBC between

--- a/notes/stories/television/tv-theamericanshortstory.st.txt
+++ b/notes/stories/television/tv-theamericanshortstory.st.txt
@@ -7,6 +7,9 @@ The American Short Story
 :: Date
 1974-1980
 
+:: Story Format
+tv
+
 :: Description
 An American television anthology series produced by Learning in Focus and Sea
 Cliff Productions for the Public Broadcasting Service (PBS). It consists of

--- a/notes/stories/television/tv-thecleopatras1983.st.txt
+++ b/notes/stories/television/tv-thecleopatras1983.st.txt
@@ -7,6 +7,9 @@ The Cleopatras
 :: Date
 1983
 
+:: Story Format
+tv
+
 :: Description
 The Cleopatras is a 1983 BBC Television eight-part historical drama serial.
 Written by Philip Mackie, it is set in Ancient Egypt during the latter part of

--- a/notes/stories/television/tv-twilightzone1959.st.txt
+++ b/notes/stories/television/tv-twilightzone1959.st.txt
@@ -7,6 +7,9 @@ The Twilight Zone
 :: Date
 1959-1964
 
+:: Story Format
+tv
+
 :: Description
 The Twilight Zone is an American anthology television series created and
 presented by Rod Serling, which ran for five seasons on CBS from 1959 to 1964.

--- a/notes/stories/television/tv-twilightzone1985.st.txt
+++ b/notes/stories/television/tv-twilightzone1985.st.txt
@@ -7,6 +7,9 @@ The Twilight Zone
 :: Date
 1985-1989
 
+:: Story Format
+tv
+
 :: Description
 The Twilight Zone (1985) is the first of three revivals of Rod Serling's
 acclaimed 1959–64 television series of the same name. It ran for two seasons

--- a/notes/stories/television/tv-twilightzone2002.st.txt
+++ b/notes/stories/television/tv-twilightzone2002.st.txt
@@ -7,6 +7,9 @@ The Twilight Zone
 :: Date
 2002-2003
 
+:: Story Format
+tv
+
 :: Description
 The Twilight Zone is the second of three revivals of Rod Serling's original
 1959–64 television series. It aired for one season on the UPN network, with

--- a/notes/stories/television/tv-twilightzone2019.st.txt
+++ b/notes/stories/television/tv-twilightzone2019.st.txt
@@ -7,6 +7,9 @@ The Twilight Zone
 :: Date
 2019-2020
 
+:: Story Format
+tv
+
 :: Description
 The Twilight Zone is an American anthology television series developed by
 Simon Kinberg, Jordan Peele, and Marco Ramirez, based on the original 1959

--- a/notes/stories/videogame/videogame-final-fantasy.st.txt
+++ b/notes/stories/videogame/videogame-final-fantasy.st.txt
@@ -7,6 +7,9 @@ Final Fantasy
 :: Date
 1987-2020
 
+:: Story Format
+game
+
 :: Description
 A Japanese anthology science fantasy media franchise created by Hironobu
 Sakaguchi, and developed and owned by Square Enix (formerly Square). The


### PR DESCRIPTION
## Summary
Adds a `:: Story Format` field to **every collection** — a high-level, objective classification of the medium (not genre): `film`, `tv`, `stage`, `prose`, `game`.

- Each collection's value is the **majority medium of its members** (derived from the folder each member story is defined in).
- The one mixed franchise, **The Twilight Zone**, is `tv`, with its six 1983/1994 **film** segments (`tz1983a`–`d`, `tz1994a`–`b`) overridden to `film` on their own story entries.
- Net change: **72 files, +399 lines** — additions only, no content edited.

## Distribution (127 collections)
film 79 · tv 39 · stage 4 · prose 4 · game 1

## Verification
Checked against **python-totolo 2.2.0** (which adds the optional `Story Format` field + validator):
- all 127 collections have a Story Format — **0 missing**
- **0 invalid** values (all within `film/tv/stage/prose/game`)
- **0 mismatches** vs each collection's member-majority
- the 6 Twilight Zone film segments correctly carry `film`
- `ThemeOntology.validate()` reports **0 story-format warnings**

This is the only net difference between `dev-stories` and `master`, isolated here as a focused diff (rather than the full dev-stories history).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
