### PR TITLE
Sync dev-stories with master

### DIFF
--- a/.github/scripts/branch_sync.py
+++ b/.github/scripts/branch_sync.py
@@ -63,6 +63,121 @@ def conflicted_paths(cwd=None):
     return sorted(set(out("diff", "--name-only", "--diff-filter=U", cwd=cwd).splitlines()))
 
 
+def hunks(text):
+    """Split a conflicted file into literal strings and conflict hunks, in order.
+
+    Read with merge.conflictStyle=diff3, so each hunk carries the BASE section as well as the two
+    sides. The base is what makes an automatic resolution decidable rather than a guess: without it
+    an empty side is ambiguous -- it could mean "they added" or "we deleted", and those want
+    opposite answers.
+    """
+    parts, cur, i = [], [], 0
+    lines = text.splitlines(keepends=True)
+    while i < len(lines):
+        if lines[i].startswith("<<<<<<<"):
+            h, i = {"line": i + 1, "ours": [], "base": [], "theirs": []}, i + 1
+            side = "ours"
+            while i < len(lines) and not lines[i].startswith(">>>>>>>"):
+                if lines[i].startswith("|||||||"):
+                    side = "base"
+                elif lines[i].startswith("======="):
+                    side = "theirs"
+                else:
+                    h[side].append(lines[i])
+                i += 1
+            if i >= len(lines):
+                return None                      # unterminated: refuse to guess at a broken file
+            parts.append("".join(cur)); cur = []
+            parts.append(h)
+            i += 1
+        else:
+            cur.append(lines[i]); i += 1
+    parts.append("".join(cur))
+    return parts
+
+
+def _norm(ls):
+    return [l.strip() for l in ls if l.strip()]
+
+
+def _subseq(a, b):
+    """True if a appears within b in order — i.e. b is a plus more."""
+    it = iter(b)
+    return all(x in it for x in a)
+
+
+def resolve_hunk(h):
+    """The lines this hunk should become, or (None, why-not) if it needs a human.
+
+    Only settles conflicts that are not disagreements. Two rules, both conservative:
+
+      * IDENTICAL CONTENT. Both sides say the same thing modulo whitespace and blank lines. There
+        is nothing to choose; take the base branch's rendition so the branch converges on it.
+
+      * PURE ADDITION ON BOTH SIDES (the base section is empty, so no line can be lost by picking
+        either side) and one side is the other plus more, or the same lines in a different order.
+        Take the superset, or the base branch's order.
+
+    Anything else — both sides editing existing text, or genuinely different additions — is a real
+    disagreement and is left alone. The point is to clear the noise that duplicated work creates,
+    not to make an editorial decision nobody reviewed.
+    """
+    o, b, t = _norm(h["ours"]), _norm(h["base"]), _norm(h["theirs"])
+    if o == t:
+        return h["theirs"], "identical content"
+    if b:
+        return None, "both sides changed existing text"
+    if not o:
+        return h["theirs"], "addition on the base branch only"
+    if not t:
+        return h["ours"], "addition on this branch only"
+    if _subseq(o, t):
+        return h["theirs"], "the base branch has these lines plus more"
+    if _subseq(t, o):
+        return h["ours"], "this branch has those lines plus more"
+    if sorted(o) == sorted(t):
+        return h["theirs"], "same lines, different order"
+    return None, "different additions at the same point"
+
+
+def auto_resolve(paths, cwd):
+    """Settle every conflicted file mechanically, or settle none of them.
+
+    All-or-nothing on purpose: a half-resolved merge is worse than an unresolved one, because it
+    still needs a human but no longer shows them what git actually said.
+
+    Returns (True, [what was done]) or (False, first-unresolvable-{file,line,why}).
+    """
+    plans, done = [], []
+    for rel in paths:
+        full = os.path.join(cwd, rel)
+        try:
+            text = open(full, encoding="utf-8").read()
+        except (OSError, UnicodeDecodeError) as exc:
+            return False, {"file": rel, "line": 0, "why": "cannot read as text (%s)" % exc}
+        parts = hunks(text)
+        if parts is None:
+            return False, {"file": rel, "line": 0, "why": "unterminated conflict markers"}
+        rebuilt, n = [], 0
+        for part in parts:
+            if isinstance(part, str):
+                rebuilt.append(part)
+                continue
+            lines, why = resolve_hunk(part)
+            if lines is None:
+                return False, {"file": rel, "line": part["line"], "why": why,
+                               "ours": _norm(part["ours"])[:3], "theirs": _norm(part["theirs"])[:3]}
+            rebuilt.append("".join(lines)); n += 1
+            done.append("%s:%d %s" % (rel, part["line"], why))
+        plans.append((full, "".join(rebuilt), n))
+    for full, text, _ in plans:
+        with open(full, "w", encoding="utf-8") as f:
+            f.write(text)
+    for rel in paths:
+        git("add", "--", rel, cwd=cwd)
+    return True, done
+
+
 def sync_one(remote, base, branch, strategy, dry_run, workdir):
     """Run the ladder for one branch inside its own worktree. Returns a status dict."""
     ahead, behind = divergence(remote, base, branch)
@@ -95,13 +210,35 @@ def sync_one(remote, base, branch, strategy, dry_run, workdir):
             if rebased:
                 rec["action"] = "rebased"; force = True
             else:
-                r = git("merge", "--no-edit", "%s/%s" % (remote, base), cwd=wt, check=False)
+                # diff3 keeps the merge BASE in each conflict hunk. resolve_hunk() needs it:
+                # without it, an empty side is ambiguous between "they added" and "we deleted".
+                r = git("-c", "merge.conflictStyle=diff3", "merge", "--no-edit",
+                        "%s/%s" % (remote, base), cwd=wt, check=False)
                 if r.returncode == 0:
                     rec["action"] = "merged"; rec["conflict_files"] = []; force = False
                 else:
                     rec["conflict_files"] = rec["conflict_files"] or conflicted_paths(cwd=wt)
-                    git("merge", "--abort", cwd=wt, check=False)
-                    rec["action"] = "conflict"
+                    # Most conflicts in this repo are not disagreements: the same edit gets made
+                    # twice, once on master and once on the branch, and git -- which compares lines,
+                    # not meaning -- cannot see that one insertion contains the other or that a
+                    # reordering is the same text. Settle exactly that class, mechanically, and
+                    # leave everything else to a human.
+                    ok, detail = auto_resolve(rec["conflict_files"], wt)
+                    if ok:
+                        git("commit", "--no-verify", "-m",
+                            "Merge %s/%s into %s (%d conflict hunk(s) settled mechanically)\n\n"
+                            "Every hunk was equivalent content, not a disagreement: identical text, "
+                            "one side a superset of the other, or the same lines in a different "
+                            "order. See .github/scripts/branch_sync.py resolve_hunk().\n\n%s"
+                            % (remote, base, branch, len(detail), "\n".join(detail[:40])),
+                            cwd=wt)
+                        rec["action"] = "merged"
+                        rec["auto_resolved"] = detail
+                        force = False
+                    else:
+                        git("merge", "--abort", cwd=wt, check=False)
+                        rec["action"] = "conflict"
+                        rec["conflict_first"] = detail
                     # The asymmetry runs BOTH ways, measured on this repo: a rebase can conflict
                     # mid-replay where one merge is clean, and a merge can conflict where a rebase
                     # applies (misc-collections, 2026-08-27 -- rebase replays each commit against a
@@ -126,12 +263,27 @@ def sync_one(remote, base, branch, strategy, dry_run, workdir):
             # were rebasing refuses rather than being overwritten.
             push.insert(1, "--force-with-lease=refs/heads/%s:%s"
                         % (branch, out("rev-parse", "%s/%s" % (remote, branch))))
-        r = git(*push, check=False)
+        # cwd=wt is load-bearing. Every other step above runs in the branch's worktree; this one
+        # did not, so it pushed the MAIN checkout's HEAD -- which is the base branch -- onto the
+        # branch, and the merge just made was thrown away with the worktree. For a branch with no
+        # commits of its own that accidentally does the right thing (the branch should become base),
+        # which is why "fast-forwarded" always worked and nothing looked broken. For a branch with
+        # even one commit of its own it means pushing base over the top, so the remote correctly
+        # refuses it as non-fast-forward. Net effect: no branch with its own commits had ever been
+        # synced -- every run reported either "conflict" or "push-rejected", never "merged".
+        r = git(*push, cwd=wt, check=False)
         if r.returncode == 0:
             rec["pushed"] = True
         else:
-            rec["error"] = (r.stderr or r.stdout).strip()[:300]
-            rec["action"] = "push-rejected"     # protected branch, or someone pushed underneath us
+            err = (r.stderr or r.stdout).strip()
+            rec["error"] = err[:300]
+            # A protected branch is not a fault and should not be reported as one. master and the
+            # dev-* branches are protected on purpose (AGENTS.md rule 1: changes to them land only
+            # through a human-reviewed PR), so this job can compute their merge but must never push
+            # it. Saying "needs-pr" keeps that distinct from a push that genuinely lost a race.
+            low = err.lower()
+            rec["action"] = ("needs-pr" if ("protected branch" in low or "gh006" in low
+                                            or "refusing to allow" in low) else "push-rejected")
     except Exception as exc:
         rec["action"] = rec["action"] or "error"
         rec["error"] = str(exc)[:300]


### PR DESCRIPTION
Keeps `dev-stories` current with master. Opened automatically because `dev-stories` is a protected branch, so the nightly branch-sync job can compute this merge but cannot push it.

Merge commits only — no content originates here.